### PR TITLE
fix: Logback configuration snippet typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,9 +751,9 @@ logbook:
 For basic Logback configuraton
 
 ```
-appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-   <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
-/appender>
+<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+</appender>
 ```
 
 configure Logbook with a `LogstashLogbackSink`


### PR DESCRIPTION
## Description

Fix a little typo on opening tags in Logback configuration snippet.

## Motivation and Context

The Logback configuration sample is currently false, `<` is missing in opening tags.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
